### PR TITLE
Changed condition from checking if a substation is selected to detect…

### DIFF
--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -461,7 +461,7 @@ public class ArmSubsystem extends SubsystemBase {
         ArmSetpoint targetArmSetpoint;
 
         // If no piece is selected, it will default to the cube pickup setpoint.
-        if (Robot.TABLET_SCORING_SUBSYSTEM.GetSubstation() != Substation.NONE) {
+        if (Robot.CLAW_SUBSYSTEM.detectsGamePiece() == false) {
             if (Robot.TABLET_SCORING_SUBSYSTEM.GetSubstation() == Substation.DOUBLE_LEFT) {
                 if (Robot.TABLET_SCORING_SUBSYSTEM.GetScoringShape() == ScoringShape.CONE) {
                     targetArmSetpoint = Constants.ARM_DOUBLE_SUBSTATION_CONE_PICKUP_SETPOINT;   


### PR DESCRIPTION
…ing a game piece

The old condition (if a substation is selected on the shuffleboard) requires the operator to deselect the substation for the arm to move to the correct scoring setpoint. The new condition (checking if we have a game piece) means the robot will know if we intend to score or load, so the operator does not have to specify.